### PR TITLE
Pmmp 3.13.0

### DIFF
--- a/src/MSpawns/MSpawns.php
+++ b/src/MSpawns/MSpawns.php
@@ -318,15 +318,11 @@ class MSpawns extends PluginBase {
         if($this->isHubExternal()){
             return $player->transfer($hub["host"], $hub["port"]) ? self::SUCCESS : self::ERR_HUB_TRANSFER;
         }
-        if(strcasecmp($player->getLevel()->getName(), $hub["world"]) != 0){
-            if(!Server::getInstance()->loadLevel($hub["world"])){
-                return self::ERR_HUB_INVALID_WORLD;
-            }
-            $level = $this->getServer()->getLevelByName($hub["world"]);
-            $player->teleport(new Position($hub["X"], $hub["Y"], $hub["Z"], $level), $hub["Yaw"], $hub["Pitch"]);
-            return self::SUCCESS;
+        if(!Server::getInstance()->loadLevel($hub["world"])){
+            return self::ERR_HUB_INVALID_WORLD;
         }
-        $player->teleport(new Position($hub["X"], $hub["Y"], $hub["Z"]), $hub["Yaw"], $hub["Pitch"]);
+        $level = $this->getServer()->getLevelByName($hub["world"]);
+        $player->teleport(new Position($hub["X"], $hub["Y"], $hub["Z"], $level), $hub["Yaw"], $hub["Pitch"]);
         return self::SUCCESS;
     }
     

--- a/src/MSpawns/MSpawns.php
+++ b/src/MSpawns/MSpawns.php
@@ -189,14 +189,14 @@ class MSpawns extends PluginBase {
      * @return bool
      */
     public function teleportToSpawn(Player $player, Level $level = null) : bool {
-        if($level){
+        if($level instanceof Level){
             $lvl = $level;
         }else{
             $lvl = $player->getLevel();
         }
         if($this->spawnExists($lvl)){
             $spawn = $this->getSpawn($lvl);
-            $player->teleport(new Position($spawn["X"], $spawn["Y"], $spawn["Z"], ($level == null) ? null : $lvl), $spawn["Yaw"], $spawn["Pitch"]);
+            $player->teleport(new Position($spawn["X"], $spawn["Y"], $spawn["Z"], $lvl), $spawn["Yaw"], $spawn["Pitch"]);
             return true;
         }
         return false;


### PR DESCRIPTION
PocketMine-MP 3.13.0 introduced a requirement to always have a valid level present when a Position is being used to teleport a player.  The changes in this PR make MSpawns compliant with this change and will fix errors that users may be experiencing that look like this:
```
2020-06-16 [02:01:29] [Server thread/CRITICAL]: pocketmine\utils\AssumptionFailedError: "Position world is null" (EXCEPTION) in "src/pocketmine/level/Position" at line 83
2020-06-16 [02:01:29] [Server thread/DEBUG]: #0 src/pocketmine/entity/Entity(1859): pocketmine\level\Position->getLevelNonNull()
2020-06-16 [02:01:29] [Server thread/DEBUG]: #1 src/pocketmine/Player(3854): pocketmine\entity\Entity->teleport(object pocketmine\level\Position, double 125.162842, double 72.414917)
2020-06-16 [02:01:29] [Server thread/DEBUG]: #2 plugins/MSpawns.phar/src/MSpawns/MSpawns(329): pocketmine\Player->teleport(object pocketmine\level\Position, double 125.162842, double 72.414917)
2020-06-16 [02:01:29] [Server thread/DEBUG]: #3 plugins/MSpawns.phar/src/MSpawns/Commands/Hub(34): MSpawns\MSpawns->teleportToHub(object pocketmine\Player)
2020-06-16 [02:01:29] [Server thread/DEBUG]: #4 src/pocketmine/command/PluginCommand(54): MSpawns\Commands\Hub->onCommand(object pocketmine\Player, object pocketmine\command\PluginCommand, string[3] hub, array[0])
2020-06-16 [02:01:29] [Server thread/DEBUG]: #5 src/pocketmine/command/SimpleCommandMap(248): pocketmine\command\PluginCommand->execute(object pocketmine\Player, string[3] hub, array[0])
2020-06-16 [02:01:29] [Server thread/DEBUG]: #6 src/pocketmine/Server(1808): pocketmine\command\SimpleCommandMap->dispatch(object pocketmine\Player, string[3] hub)
2020-06-16 [02:01:29] [Server thread/DEBUG]: #7 src/pocketmine/Player(2283): pocketmine\Server->dispatchCommand(object pocketmine\Player, string[3] hub)
2020-06-16 [02:01:29] [Server thread/DEBUG]: #8 src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter(244): pocketmine\Player->chat(string[4] /hub)
```